### PR TITLE
Fix: MCUserAuth is now use MCUserAuthStatus enum as status instead of boolean

### DIFF
--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/authentication/MCUserAuth.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/authentication/MCUserAuth.kt
@@ -4,18 +4,18 @@ import java.util.UUID
 
 object MCUserAuth {
 
-    private val authorizedUser = HashMap<UUID, Boolean>()
+    private val authorizedUser = HashMap<UUID, MCUserAuthStatus>()
 
     /**
      *
      * Sets the user authorization status.
      *
      * @param minecraftUUID UUID of Player
-     * @param isAuthorized authorization status
+     * @param authStatus authorization status
      */
     @JvmStatic
-    fun setUserAuthorizedStatus(minecraftUUID: UUID ,isAuthorized: Boolean) {
-        authorizedUser[minecraftUUID] = isAuthorized
+    fun setUserAuthorizationStatus(minecraftUUID: UUID, authStatus: MCUserAuthStatus) {
+        authorizedUser[minecraftUUID] = authStatus
     }
 
     /**
@@ -23,14 +23,10 @@ object MCUserAuth {
      * Checks user is authorized.
      *
      * @param minecraftUUID UUID of Player
-     * @return true if authorized, otherwise false
+     * @return Returns MCUserAuthStatus enum
      */
     @JvmStatic
-    fun isUserAuthorized(minecraftUUID: UUID): Boolean{
-        // Return value of `authorizedUser[key]` is `Boolean?` not `Boolean` and need a null check so use when.
-        return when(authorizedUser[minecraftUUID]) {
-            true -> true
-            else -> false
-        }
+    fun getUserAuthorizationStatus(minecraftUUID: UUID): MCUserAuthStatus{
+        return authorizedUser[minecraftUUID] ?: MCUserAuthStatus.NOT_AUTHORIZED
     }
 }

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/authentication/MCUserAuthStatus.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/authentication/MCUserAuthStatus.kt
@@ -1,0 +1,7 @@
+package com.github.shunsukesudo.minecraft2fa.shared.authentication
+
+enum class MCUserAuthStatus {
+    AUTHORIZED,
+    AUTHORIZE_PENDING,
+    NOT_AUTHORIZED
+}

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/discord/commands/AuthCommand.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/discord/commands/AuthCommand.kt
@@ -1,6 +1,7 @@
 package com.github.shunsukesudo.minecraft2fa.shared.discord.commands
 
 import com.github.shunsukesudo.minecraft2fa.shared.authentication.MCUserAuth
+import com.github.shunsukesudo.minecraft2fa.shared.authentication.MCUserAuthStatus
 import com.github.shunsukesudo.minecraft2fa.shared.authentication.User2FA
 import com.github.shunsukesudo.minecraft2fa.shared.discord.DiscordBot
 import com.github.shunsukesudo.minecraft2fa.shared.event.MC2FAEvent
@@ -195,7 +196,7 @@ class AuthCommand: ListenerAdapter() {
 
         val uuid = UUID.fromString(database.integration().getMinecraftUUIDFromDiscordID(event.user.idLong))
 
-        if(MCUserAuth.isUserAuthorized(uuid)) {
+        if(MCUserAuth.getUserAuthorizationStatus(uuid) == MCUserAuthStatus.AUTHORIZED) {
             event.reply("You are already in verified session! session will expire in {}")
             return
         }

--- a/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/authentication/MCUserAuthTest.kt
+++ b/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/authentication/MCUserAuthTest.kt
@@ -1,6 +1,7 @@
 package com.github.shunsukesudo.minecraft2fa.tests.shared.authentication
 
 import com.github.shunsukesudo.minecraft2fa.shared.authentication.MCUserAuth
+import com.github.shunsukesudo.minecraft2fa.shared.authentication.MCUserAuthStatus
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.util.*
@@ -14,10 +15,10 @@ class MCUserAuthTest {
     @Test
     fun `Test - Should return false when uninitialized value accessed`() {
         println("=========== Test - Should return false when uninitialized value accessed")
-        val expectedValue = false
+        val expectedValue = MCUserAuthStatus.NOT_AUTHORIZED
 
         println("Calling: MCUserAuth.isUserAuthorized()")
-        val actualValue = MCUserAuth.isUserAuthorized(UUID.randomUUID())
+        val actualValue = MCUserAuth.getUserAuthorizationStatus(UUID.randomUUID())
 
         println("Expected value: $expectedValue | Actual value: $actualValue")
         Assertions.assertEquals(expectedValue, actualValue)
@@ -30,27 +31,27 @@ class MCUserAuthTest {
         println("=========== Test - Should return individual value when initialized value accessed")
 
         val uuids: MutableList<UUID> = mutableListOf()
-        val expectedValues: HashMap<UUID, Boolean> = HashMap()
+        val expectedValues: HashMap<UUID, MCUserAuthStatus> = HashMap()
 
         for(i in 1..5) {
             uuids.add(UUID.randomUUID())
         }
 
-        var booleanVal: Boolean
+        var authorizedStatus: MCUserAuthStatus
 
         uuids.forEach {
-            booleanVal = random.nextBoolean()
+            authorizedStatus = MCUserAuthStatus.values().random()
             println("Generated UUID: $it")
             println("Calling: MCUserAuth.setUserAuthorizedStatus() for user: $it")
-            MCUserAuth.setUserAuthorizedStatus(it, booleanVal)
-            expectedValues[it] = booleanVal
+            MCUserAuth.setUserAuthorizationStatus(it, authorizedStatus)
+            expectedValues[it] = authorizedStatus
         }
 
-        var actualValue: Boolean
-        var expectedValue: Boolean
+        var actualValue: MCUserAuthStatus
+        var expectedValue: MCUserAuthStatus
 
         uuids.forEach {
-            actualValue = MCUserAuth.isUserAuthorized(it)
+            actualValue = MCUserAuth.getUserAuthorizationStatus(it)
             expectedValue = expectedValues[it]!!
             println("Expected value: $expectedValue | Actual value: $actualValue")
             Assertions.assertEquals(expectedValue, actualValue)


### PR DESCRIPTION
## Link to ticket

* https://github.com/ShunsukeSudo/Minecraft2FA-Remake/issues/16

## What I did

* Changed MCUserAuth to use MCUserAuthStatus for status instead of boolean.

## What I didn't do

* Nothing

## Operation check

Done with JUnit test.