### PR TITLE
21 create shared configuration

### DIFF
--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/AuthenticationConfiguration.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/AuthenticationConfiguration.kt
@@ -1,0 +1,10 @@
+package com.github.shunsukesudo.minecraft2fa.shared.configuration
+
+data class AuthenticationConfiguration(
+    val sessionExpireTimeInSeconds: Int,
+) {
+    init {
+        if(sessionExpireTimeInSeconds < 0)
+            throw IllegalArgumentException("sessionExpireTimeInSeconds should not be negative value! $sessionExpireTimeInSeconds")
+    }
+}

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/AuthenticationConfiguration.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/AuthenticationConfiguration.kt
@@ -6,5 +6,8 @@ data class AuthenticationConfiguration(
     init {
         if(sessionExpireTimeInSeconds < 0)
             throw IllegalArgumentException("sessionExpireTimeInSeconds should not be negative value! $sessionExpireTimeInSeconds")
+
+        if(sessionExpireTimeInSeconds == 0)
+            throw IllegalArgumentException("sessionExpireTimeInSeconds should greater than 1!")
     }
 }

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DatabaseConfiguration.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DatabaseConfiguration.kt
@@ -10,7 +10,7 @@ data class DatabaseConfiguration(
         when(databaseType) {
             DatabaseType.MYSQL -> {
                 if(address.isEmpty()) {
-                    throw IllegalStateException("Address is should not be empty.")
+                    throw IllegalArgumentException("Address is should not be empty.")
                 }
 
                 if(user.isEmpty()) {
@@ -24,7 +24,7 @@ data class DatabaseConfiguration(
 
             DatabaseType.SQLITE -> {
                 if(address.isEmpty()) {
-                    throw IllegalStateException("Address is should not be empty.")
+                    throw IllegalArgumentException("Address is should not be empty.")
                 }
             }
 

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DatabaseConfiguration.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DatabaseConfiguration.kt
@@ -16,10 +16,6 @@ data class DatabaseConfiguration(
                 if(user.isEmpty()) {
                     throw IllegalArgumentException("User is should not be empty in $databaseType database")
                 }
-
-                if(password.isEmpty()) {
-                    throw IllegalArgumentException("Password is should not empty in $databaseType database")
-                }
             }
 
             DatabaseType.SQLITE -> {

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DatabaseConfiguration.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DatabaseConfiguration.kt
@@ -19,10 +19,6 @@ data class DatabaseConfiguration(
 
             DatabaseType.SQLITE -> {
             }
-
-            else -> {
-                throw IllegalArgumentException("Unknown database type specified. Type: $databaseType")
-            }
         }
     }
 }

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DatabaseConfiguration.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DatabaseConfiguration.kt
@@ -7,21 +7,17 @@ data class DatabaseConfiguration(
     val password: String
 ) {
     init {
+        if(address.isEmpty())
+            throw IllegalArgumentException("Address is should not be empty.")
+
         when(databaseType) {
             DatabaseType.MYSQL -> {
-                if(address.isEmpty()) {
-                    throw IllegalArgumentException("Address is should not be empty.")
-                }
-
                 if(user.isEmpty()) {
                     throw IllegalArgumentException("User is should not be empty in $databaseType database")
                 }
             }
 
             DatabaseType.SQLITE -> {
-                if(address.isEmpty()) {
-                    throw IllegalArgumentException("Address is should not be empty.")
-                }
             }
 
             else -> {

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DatabaseConfiguration.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DatabaseConfiguration.kt
@@ -3,7 +3,7 @@ package com.github.shunsukesudo.minecraft2fa.shared.configuration
 data class DatabaseConfiguration(
     val databaseType: DatabaseType,
     val address: String,
-    val user: String,
+    val userName: String,
     val password: String
 ) {
     init {
@@ -12,7 +12,7 @@ data class DatabaseConfiguration(
 
         when(databaseType) {
             DatabaseType.MYSQL -> {
-                if(user.isEmpty()) {
+                if(userName.isEmpty()) {
                     throw IllegalArgumentException("User is should not be empty in $databaseType database")
                 }
             }

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DatabaseConfiguration.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DatabaseConfiguration.kt
@@ -1,0 +1,36 @@
+package com.github.shunsukesudo.minecraft2fa.shared.configuration
+
+data class DatabaseConfiguration(
+    val databaseType: DatabaseType,
+    val address: String,
+    val user: String,
+    val password: String
+) {
+    init {
+        when(databaseType) {
+            DatabaseType.MYSQL -> {
+                if(address.isEmpty()) {
+                    throw IllegalStateException("Address is should not be empty.")
+                }
+
+                if(user.isEmpty()) {
+                    throw IllegalArgumentException("User is should not be empty in $databaseType database")
+                }
+
+                if(password.isEmpty()) {
+                    throw IllegalArgumentException("Password is should not empty in $databaseType database")
+                }
+            }
+
+            DatabaseType.SQLITE -> {
+                if(address.isEmpty()) {
+                    throw IllegalStateException("Address is should not be empty.")
+                }
+            }
+
+            else -> {
+                throw IllegalArgumentException("Unknown database type specified. Type: $databaseType")
+            }
+        }
+    }
+}

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DatabaseType.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DatabaseType.kt
@@ -1,0 +1,6 @@
+package com.github.shunsukesudo.minecraft2fa.shared.configuration
+
+enum class DatabaseType {
+    SQLITE,
+    MYSQL
+}

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DiscordBotConfiguration.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DiscordBotConfiguration.kt
@@ -3,4 +3,8 @@ package com.github.shunsukesudo.minecraft2fa.shared.configuration
 data class DiscordBotConfiguration(
     val botToken: String
 ) {
+    init {
+        if(botToken.isEmpty())
+            throw IllegalArgumentException("Bot token is should not empty!")
+    }
 }

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DiscordBotConfiguration.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DiscordBotConfiguration.kt
@@ -1,0 +1,6 @@
+package com.github.shunsukesudo.minecraft2fa.shared.configuration
+
+data class DiscordBotConfiguration(
+    val botToken: String
+) {
+}

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/PluginConfiguration.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/PluginConfiguration.kt
@@ -1,0 +1,8 @@
+package com.github.shunsukesudo.minecraft2fa.shared.configuration
+
+data class PluginConfiguration(
+    val authConfiguration: AuthenticationConfiguration,
+    val databaseConfiguration: DatabaseConfiguration,
+    val discordBotConfiguration: DiscordBotConfiguration
+) {
+}

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/database/DatabaseFactory.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/database/DatabaseFactory.kt
@@ -1,21 +1,17 @@
 package com.github.shunsukesudo.minecraft2fa.shared.database
 
+import com.github.shunsukesudo.minecraft2fa.shared.configuration.DatabaseConfiguration
+
 object DatabaseFactory {
     object SQLite {
-        fun newConnection(databaseName: String): MC2FADatabase {
-            if(!databaseName.endsWith(".db"))
-                return SQLiteDatabase(databaseName.plus(".db"))
-
-            return SQLiteDatabase(databaseName)
+        fun newConnection(databaseConfiguration: DatabaseConfiguration): MC2FADatabase {
+            return SQLiteDatabase(databaseConfiguration)
         }
     }
 
     object MySQL {
-        fun newConnection(address: String, databaseName: String, properties: String, user: String, password: String): MC2FADatabase {
-            return MySQLDatabase(address, databaseName, properties, user, password)
-        }
-        fun newConnection(address: String, databaseName: String, user: String, password: String): MC2FADatabase {
-            return MySQLDatabase(address, databaseName, "", user, password)
+        fun newConnection(databaseConfiguration: DatabaseConfiguration): MC2FADatabase {
+            return MySQLDatabase(databaseConfiguration)
         }
     }
 }

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/database/MySQLDatabase.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/database/MySQLDatabase.kt
@@ -1,19 +1,22 @@
 package com.github.shunsukesudo.minecraft2fa.shared.database
 
+import com.github.shunsukesudo.minecraft2fa.shared.configuration.DatabaseConfiguration
+import com.github.shunsukesudo.minecraft2fa.shared.configuration.PluginConfiguration
 import com.github.shunsukesudo.minecraft2fa.shared.database.auth.Authentication
 import com.github.shunsukesudo.minecraft2fa.shared.database.integration.Integration
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 
 internal class MySQLDatabase(
-    databaseAddress: String,
-    databaseName: String,
-    properties: String,
-    user: String,
-    password: String
+    databaseConfiguration: DatabaseConfiguration
 ) : MC2FADatabase {
 
-    private val database = Database.connect(url = "jdbc:mySQL://$databaseAddress/$databaseName$properties", driver = "com.mysql.cj.jdbc.Driver", user = user, password = password)
+    private val database = Database.connect(
+        url = "jdbc:mySQL://${databaseConfiguration.address}",
+        driver = "com.mysql.cj.jdbc.Driver",
+        user = databaseConfiguration.userName,
+        password = databaseConfiguration.userName
+    )
     private val authentication = Authentication(this.database)
     private val integration = Integration(this.database)
 

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/database/SQLiteDatabase.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/database/SQLiteDatabase.kt
@@ -1,5 +1,7 @@
 package com.github.shunsukesudo.minecraft2fa.shared.database
 
+import com.github.shunsukesudo.minecraft2fa.shared.configuration.DatabaseConfiguration
+import com.github.shunsukesudo.minecraft2fa.shared.configuration.PluginConfiguration
 import com.github.shunsukesudo.minecraft2fa.shared.database.auth.Authentication
 import com.github.shunsukesudo.minecraft2fa.shared.database.integration.Integration
 import org.jetbrains.exposed.sql.Database
@@ -7,10 +9,13 @@ import org.jetbrains.exposed.sql.transactions.TransactionManager
 import java.sql.Connection
 
 internal class SQLiteDatabase(
-    databaseName: String,
+    databaseConfiguration: DatabaseConfiguration,
 ) : MC2FADatabase {
 
-    private val database = Database.connect(url = "jdbc:sqlite://$databaseName", driver = "org.sqlite.JDBC")
+    private val database = Database.connect(
+        url = "jdbc:sqlite://${databaseConfiguration.address}",
+        driver = "org.sqlite.JDBC"
+    )
     private val authentication = Authentication(this.database)
     private val integration = Integration(this.database)
 

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/discord/DiscordBot.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/discord/DiscordBot.kt
@@ -1,5 +1,7 @@
 package com.github.shunsukesudo.minecraft2fa.shared.discord
 
+import com.github.shunsukesudo.minecraft2fa.shared.configuration.DiscordBotConfiguration
+import com.github.shunsukesudo.minecraft2fa.shared.configuration.PluginConfiguration
 import com.github.shunsukesudo.minecraft2fa.shared.database.MC2FADatabase
 import dev.creativition.simplejdautil.SimpleJDAUtil
 import net.dv8tion.jda.api.JDA
@@ -9,7 +11,7 @@ import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionE
 import net.dv8tion.jda.api.requests.GatewayIntent
 
 class DiscordBot(
-    discordBotToken: String,
+    discordBotConfiguration: DiscordBotConfiguration,
     database: MC2FADatabase
 ) {
 
@@ -35,7 +37,7 @@ class DiscordBot(
     val jda: JDA
 
     init {
-        val jdaBuilder = JDABuilder.createDefault(discordBotToken)
+        val jdaBuilder = JDABuilder.createDefault(discordBotConfiguration.botToken)
 
         jdaBuilder.enableIntents(GatewayIntent.MESSAGE_CONTENT)
 

--- a/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/configuration/AuthenticationConfigurationTest.kt
+++ b/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/configuration/AuthenticationConfigurationTest.kt
@@ -1,0 +1,59 @@
+package com.github.shunsukesudo.minecraft2fa.tests.shared.configuration
+
+import com.github.shunsukesudo.minecraft2fa.shared.configuration.AuthenticationConfiguration
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.*
+import kotlin.random.Random
+
+class AuthenticationConfigurationTest {
+
+    private val random = Random(UUID.randomUUID().toString().filter { it.isDigit() }.take(16).toLong())
+    
+    @Test
+    fun `Test - should throw IllegalArgumentException when construct with negative value`() {
+        println("=========== Test - should throw IllegalArgumentException when construct with negative value")
+        assertThrows<IllegalArgumentException> {
+            var randomInt = random.nextInt()
+            if(randomInt > 0) randomInt = randomInt.inv()
+            println("Constructing with generated random negative int: $randomInt")
+            println("Checking constructor of AuthenticationConfiguration throw exception")
+            val sut = AuthenticationConfiguration(randomInt)
+        }
+        
+        println("Passed.")
+    }
+
+    @Test
+    fun `Test - should throw IllegalArgumentException when construct with 0`() {
+        println("=========== Test - should throw IllegalArgumentException when construct with 0")
+        assertThrows<IllegalArgumentException> {
+            val expectedInt = 0
+            println("Constructing with $expectedInt")
+            println("Checking constructor of AuthenticationConfiguration throw exception")
+            val sut = AuthenticationConfiguration(expectedInt)
+        }
+
+        println("Passed.")
+    }
+    
+    @Test
+    fun `Test - should return actual value after instanced`() {
+        println("=========== Test - should return actual value after instanced")
+        var expectedValue = random.nextInt()
+        if(expectedValue < 0) expectedValue = expectedValue.inv()
+        println("Expected value: $expectedValue")
+
+        println("Instancing AuthenticationConfiguration")
+        val sut = AuthenticationConfiguration(expectedValue)
+
+        val actualValue = sut.sessionExpireTimeInSeconds
+        println("Actual value from instanced AuthenticationConfiguration: $actualValue")
+
+        println("Expected value: $expectedValue | Actual value: $actualValue")
+        Assertions.assertEquals(expectedValue, actualValue)
+        
+        println("Passed")
+    }
+}

--- a/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/configuration/DatabaseConfigurationTest.kt
+++ b/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/configuration/DatabaseConfigurationTest.kt
@@ -1,0 +1,79 @@
+package com.github.shunsukesudo.minecraft2fa.tests.shared.configuration
+
+import com.github.shunsukesudo.minecraft2fa.shared.configuration.DatabaseConfiguration
+import com.github.shunsukesudo.minecraft2fa.shared.configuration.DatabaseType
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class DatabaseConfigurationTest {
+
+    @Test
+    fun `Test - should throw exception when DatabaseType is MYSQL and user name is empty`() {
+        println("=========== Test - should throw exception when DatabaseType is MYSQL and user name is empty")
+
+        val databaseType = DatabaseType.MYSQL
+        val address = "address.adr:1000"
+        val userName = ""
+        val password = ""
+
+        println("Constructing DatabaseConfiguration with these values.")
+        println("databaseType: $databaseType, address: $address, user: $userName, password: $password")
+
+        assertThrows<IllegalArgumentException> {
+            println("Should throw IllegalArgumentException because user name is empty")
+            val sut = DatabaseConfiguration(databaseType, address, userName, password)
+        }
+
+        println("Passed.")
+    }
+
+    @Test
+    fun `Test - should throw exception when address is empty`() {
+        println("=========== Test - should throw exception when address is empty")
+
+        val databaseType = DatabaseType.MYSQL
+        val address = ""
+        val userName = "UserName"
+        val password = "PasSWorD"
+
+        println("Constructing DatabaseConfiguration with these values.")
+        println("databaseType: $databaseType, address: $address, user: $userName, password: $password")
+
+        assertThrows<IllegalArgumentException> {
+            println("Should throw IllegalArgumentException because address is empty")
+            val sut = DatabaseConfiguration(databaseType, address, userName, password)
+        }
+
+        println("Passed.")
+    }
+
+    @Test
+    fun `Test - should return expected value after instanced`() {
+        println("=========== Test - should return expected value after instanced")
+
+        val databaseType = DatabaseType.SQLITE
+        val address = "Address:1000"
+        val userName = "UserName"
+        val password = "PasSWorD"
+
+        println("Constructing DatabaseConfiguration with these values.")
+        println("databaseType: $databaseType, address: $address, user: $userName, password: $password")
+
+        val sut = DatabaseConfiguration(databaseType, address, userName, password)
+
+        println("Expected databaseType: $databaseType | Actual databaseType: ${sut.databaseType}")
+        Assertions.assertEquals(databaseType, sut.databaseType)
+
+        println("Expected address: $address | Actual address: ${sut.address}")
+        Assertions.assertEquals(address, sut.address)
+
+        println("Expected user name: $userName | Actual user name: ${sut.userName}")
+        Assertions.assertEquals(userName, sut.userName)
+
+        println("Expected address: $password | Actual address: ${sut.password}")
+        Assertions.assertEquals(password, sut.password)
+
+        println("Passed.")
+    }
+}

--- a/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/configuration/DiscordBotConfigurationTest.kt
+++ b/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/configuration/DiscordBotConfigurationTest.kt
@@ -1,0 +1,39 @@
+package com.github.shunsukesudo.minecraft2fa.tests.shared.configuration
+
+import com.github.shunsukesudo.minecraft2fa.shared.configuration.DiscordBotConfiguration
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class DiscordBotConfigurationTest {
+
+    @Test
+    fun `Test - should throw exception when bot token is empty`() {
+        println("=========== Test - should throw exception when bot token is empty")
+
+        println("Instancing DiscordBotConfiguration with empty string")
+        assertThrows<IllegalArgumentException> {
+            val sut = DiscordBotConfiguration("")
+        }
+
+        println("Passed.")
+    }
+
+    @Test
+    fun `Test - should return expected value after instanced`() {
+        println("=========== Test - should return expected value after instanced")
+
+        val alphabet = ('a'..'z') + ('A'..'Z') + ('0'..'9')
+        val len = 32
+        val expectedValue = (1..len).map { alphabet.random() }.joinToString("")
+
+        println("Instancing with token: $expectedValue")
+        val sut = DiscordBotConfiguration(expectedValue)
+
+        val actualValue = sut.botToken
+
+        println("Expected value: $expectedValue | Actual value: $actualValue")
+        Assertions.assertEquals(expectedValue, actualValue)
+        println("Passed.")
+    }
+}

--- a/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/configuration/PluginConfigurationTest.kt
+++ b/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/configuration/PluginConfigurationTest.kt
@@ -1,0 +1,65 @@
+package com.github.shunsukesudo.minecraft2fa.tests.shared.configuration
+
+import com.github.shunsukesudo.minecraft2fa.shared.configuration.*
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class PluginConfigurationTest {
+
+
+    @Test
+    fun `Test - should return expected value after instanced`() {
+        val authConfigExpectedSessionExpireTimeInSeconds = 50
+        val authConfiguration = AuthenticationConfiguration(authConfigExpectedSessionExpireTimeInSeconds)
+
+        val dbConfigExpectedDatabaseType = DatabaseType.MYSQL
+        val dbConfigExpectedAddress = "Address.adr:1000"
+        val dbConfigExpectedUserName = "UserName"
+        val dbConfigExpectedPassword = "PAssWoRd"
+        val databaseConfiguration = DatabaseConfiguration(dbConfigExpectedDatabaseType, dbConfigExpectedAddress, dbConfigExpectedUserName, dbConfigExpectedPassword)
+
+        val discordConfigExpectedToken = "Token"
+        val discordBotConfiguration = DiscordBotConfiguration(discordConfigExpectedToken)
+
+
+        val pluginConfiguration = PluginConfiguration(authConfiguration, databaseConfiguration, discordBotConfiguration)
+
+        println("-- Auth config")
+        println("Expected: $authConfigExpectedSessionExpireTimeInSeconds | Actual: ${pluginConfiguration.authConfiguration.sessionExpireTimeInSeconds}")
+        Assertions.assertEquals(
+            authConfigExpectedSessionExpireTimeInSeconds,
+            pluginConfiguration.authConfiguration.sessionExpireTimeInSeconds
+        )
+
+        println("-- Database config")
+        println("Expected: $dbConfigExpectedDatabaseType | Actual: ${pluginConfiguration.databaseConfiguration.databaseType}")
+        Assertions.assertEquals(
+            dbConfigExpectedDatabaseType,
+            pluginConfiguration.databaseConfiguration.databaseType
+        )
+        println("Expected: $dbConfigExpectedAddress | Actual: ${pluginConfiguration.databaseConfiguration.address}")
+        Assertions.assertEquals(
+            dbConfigExpectedAddress,
+            pluginConfiguration.databaseConfiguration.address
+        )
+        println("Expected: $dbConfigExpectedUserName | Actual: ${pluginConfiguration.databaseConfiguration.userName}")
+        Assertions.assertEquals(
+            dbConfigExpectedUserName,
+            pluginConfiguration.databaseConfiguration.userName
+        )
+        println("Expected: $dbConfigExpectedPassword | Actual: ${pluginConfiguration.databaseConfiguration.password}")
+        Assertions.assertEquals(
+            dbConfigExpectedPassword,
+            pluginConfiguration.databaseConfiguration.password
+        )
+
+        println("-- DiscordBot config")
+        println("Expected: $discordConfigExpectedToken | Actual: ${pluginConfiguration.discordBotConfiguration.botToken}")
+        Assertions.assertEquals(
+            discordConfigExpectedToken,
+            pluginConfiguration.discordBotConfiguration.botToken
+        )
+
+
+    }
+}

--- a/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/database/auth/AuthenticationTest.kt
+++ b/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/database/auth/AuthenticationTest.kt
@@ -1,5 +1,7 @@
 package com.github.shunsukesudo.minecraft2fa.tests.shared.database.auth
 
+import com.github.shunsukesudo.minecraft2fa.shared.configuration.DatabaseConfiguration
+import com.github.shunsukesudo.minecraft2fa.shared.configuration.DatabaseType
 import com.github.shunsukesudo.minecraft2fa.shared.database.DatabaseFactory
 import com.github.shunsukesudo.minecraft2fa.shared.database.MC2FADatabase
 import com.github.shunsukesudo.minecraft2fa.shared.database.auth.AuthBackupCodeTable
@@ -19,7 +21,8 @@ class AuthenticationTest {
     companion object {
         private val random = Random(UUID.randomUUID().toString().filter { it.isDigit() }.take(16).toLong())
         private val dbPath = "${File(".").canonicalPath}/test-database.db"
-        val database: MC2FADatabase = DatabaseFactory.SQLite.newConnection(dbPath)
+        private val dbConfig = DatabaseConfiguration(DatabaseType.SQLITE, dbPath, "", "")
+        val database: MC2FADatabase = DatabaseFactory.SQLite.newConnection(dbConfig)
 
         init {
             transaction(database.getDatabaseConnection()) {

--- a/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/database/integration/IntegrationTest.kt
+++ b/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/database/integration/IntegrationTest.kt
@@ -1,5 +1,7 @@
 package com.github.shunsukesudo.minecraft2fa.tests.shared.database.integration
 
+import com.github.shunsukesudo.minecraft2fa.shared.configuration.DatabaseConfiguration
+import com.github.shunsukesudo.minecraft2fa.shared.configuration.DatabaseType
 import com.github.shunsukesudo.minecraft2fa.shared.database.DatabaseFactory
 import com.github.shunsukesudo.minecraft2fa.shared.database.MC2FADatabase
 import com.github.shunsukesudo.minecraft2fa.shared.database.integration.IntegrationInfoTable
@@ -17,7 +19,8 @@ class IntegrationTest {
     companion object {
         private val random = Random(UUID.randomUUID().toString().filter { it.isDigit() }.take(16).toLong())
         private val dbPath = "${File(".").canonicalPath}/test-database.db"
-        val database: MC2FADatabase = DatabaseFactory.SQLite.newConnection(dbPath)
+        private val dbConfig = DatabaseConfiguration(DatabaseType.SQLITE, dbPath, "", "")
+        val database: MC2FADatabase = DatabaseFactory.SQLite.newConnection(dbConfig)
 
         init {
             transaction(database.getDatabaseConnection()) {


### PR DESCRIPTION
## Link to ticket

* https://github.com/ShunsukeSudo/Minecraft2FA-Remake/issues/21

## What I did

* Add configuration class for shared modules.

### Why?

Shared modules shouldn't access the paper/waterfall module. 
but values like discord bot token, MySQL user, password, address and etc... is should make configuration class for maintainability.

## What I didn't do

* Nothing

## Operation check

Done with JUnit test.