### PR TITLE
Merge newConnection() method to one method

### DIFF
--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/database/DatabaseFactory.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/database/DatabaseFactory.kt
@@ -1,17 +1,13 @@
 package com.github.shunsukesudo.minecraft2fa.shared.database
 
 import com.github.shunsukesudo.minecraft2fa.shared.configuration.DatabaseConfiguration
+import com.github.shunsukesudo.minecraft2fa.shared.configuration.DatabaseType
 
 object DatabaseFactory {
-    object SQLite {
-        fun newConnection(databaseConfiguration: DatabaseConfiguration): MC2FADatabase {
-            return SQLiteDatabase(databaseConfiguration)
-        }
-    }
-
-    object MySQL {
-        fun newConnection(databaseConfiguration: DatabaseConfiguration): MC2FADatabase {
-            return MySQLDatabase(databaseConfiguration)
+    fun newConnection(databaseConfiguration: DatabaseConfiguration): MC2FADatabase {
+        return when(databaseConfiguration.databaseType) {
+            DatabaseType.SQLITE -> SQLiteDatabase(databaseConfiguration)
+            DatabaseType.MYSQL -> MySQLDatabase(databaseConfiguration)
         }
     }
 }

--- a/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/database/auth/AuthenticationTest.kt
+++ b/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/database/auth/AuthenticationTest.kt
@@ -22,7 +22,7 @@ class AuthenticationTest {
         private val random = Random(UUID.randomUUID().toString().filter { it.isDigit() }.take(16).toLong())
         private val dbPath = "${File(".").canonicalPath}/test-database.db"
         private val dbConfig = DatabaseConfiguration(DatabaseType.SQLITE, dbPath, "", "")
-        val database: MC2FADatabase = DatabaseFactory.SQLite.newConnection(dbConfig)
+        val database: MC2FADatabase = DatabaseFactory.newConnection(dbConfig)
 
         init {
             transaction(database.getDatabaseConnection()) {

--- a/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/database/integration/IntegrationTest.kt
+++ b/shared/src/test/java/com/github/shunsukesudo/minecraft2fa/tests/shared/database/integration/IntegrationTest.kt
@@ -20,7 +20,7 @@ class IntegrationTest {
         private val random = Random(UUID.randomUUID().toString().filter { it.isDigit() }.take(16).toLong())
         private val dbPath = "${File(".").canonicalPath}/test-database.db"
         private val dbConfig = DatabaseConfiguration(DatabaseType.SQLITE, dbPath, "", "")
-        val database: MC2FADatabase = DatabaseFactory.SQLite.newConnection(dbConfig)
+        val database: MC2FADatabase = DatabaseFactory.newConnection(dbConfig)
 
         init {
             transaction(database.getDatabaseConnection()) {


### PR DESCRIPTION
## Link to ticket

* https://github.com/ShunsukeSudo/Minecraft2FA-Remake/issues/26

## What I did

* Merge [DatabaseFactory](https://github.com/ShunsukeSudo/Minecraft2FA-Remake/blob/main/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/database/DatabaseFactory.kt)'s static `newConnection()` method to one static `newConnection()` method.

### Why?

Since I added the [DatabaseConfiguration](https://github.com/ShunsukeSudo/Minecraft2FA-Remake/blob/main/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DatabaseConfiguration.kt) and this class have [DatabaseType](https://github.com/ShunsukeSudo/Minecraft2FA-Remake/blob/main/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/configuration/DatabaseType.kt) as member value.

Also `newConnection()` method retrieves DatabaseConfiguration as argument.

So we can decide database class implementation to return in one method.

## What I didn't do

* Nothing

## Operation check

Done with JUnit test.