### PR TITLE
Fix plugin name

### DIFF
--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
 }
 
 bukkit {
+    name = rootProject.name
     main =  "${project.ext["groupID"]}.minecraft2fa.paper.Minecraft2FA"
 
     apiVersion = "1.13"

--- a/waterfall/build.gradle.kts
+++ b/waterfall/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
 }
 
 bungee {
+    name = rootProject.name
     main = "${project.ext["groupID"]}.minecraft2fa.waterfall.Minecraft2FA"
     author = project.ext["authorName"].toString()
     version = project.ext["pluginVersion"].toString()


### PR DESCRIPTION
## Link to ticket

* https://github.com/ShunsukeSudo/Minecraft2FA-Remake/issues/31

## What I did

* Fix plugin name to use root project name

### Why?

* net.minecrell.plugin-yml is use module to plugin name by default.

## What I didn't do

* Nothing