### PR TITLE
Implement plugin messaging channel communication between server and proxy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ subprojects {
 
     dependencies {
         implementation("net.dv8tion:JDA:5.0.0-beta.21")
-        implementation("dev.creativition:simplejdautil:0.0.1")
+        implementation("dev.creativition:simplejdautil:0.0.2")
         implementation("org.jetbrains.kotlin:kotlin-reflect")
         implementation("net.kyori:adventure-platform-bungeecord:4.3.0")
         implementation("net.kyori:adventure-platform-bukkit:4.3.0")

--- a/paper/src/main/java/com/github/shunsukesudo/minecraft2fa/paper/Minecraft2FA.kt
+++ b/paper/src/main/java/com/github/shunsukesudo/minecraft2fa/paper/Minecraft2FA.kt
@@ -16,6 +16,7 @@ class Minecraft2FA: JavaPlugin(), IPlugin {
     companion object {
         private lateinit var pluginConfig: PluginConfiguration
         private lateinit var pluginDatabase: MC2FADatabase
+        private lateinit var pluginInstance: JavaPlugin
 
         fun getPluginConfig(): PluginConfiguration {
             return pluginConfig
@@ -24,10 +25,15 @@ class Minecraft2FA: JavaPlugin(), IPlugin {
         fun getDatabase(): MC2FADatabase {
             return pluginDatabase
         }
+
+        fun getInstance(): JavaPlugin {
+            return pluginInstance
+        }
     }
 
     init {
         SharedPlugin.plugin = this
+        pluginInstance = this
     }
 
     override val pluginConfiguration: PluginConfiguration

--- a/paper/src/main/java/com/github/shunsukesudo/minecraft2fa/paper/events/PlayerJoinListener.kt
+++ b/paper/src/main/java/com/github/shunsukesudo/minecraft2fa/paper/events/PlayerJoinListener.kt
@@ -21,7 +21,7 @@ class PlayerJoinListener: Listener {
         outStream.writeUTF(event.player.uniqueId.toString())
 
         plugin.server.scheduler.runTaskLater(plugin, Runnable {
-            event.player.sendPluginMessage(plugin, "mc2fa:authentication", outStream.toByteArray())
+            player.sendPluginMessage(plugin, "mc2fa:authentication", outStream.toByteArray())
         }, 30)
     }
 }

--- a/paper/src/main/java/com/github/shunsukesudo/minecraft2fa/paper/events/PlayerJoinListener.kt
+++ b/paper/src/main/java/com/github/shunsukesudo/minecraft2fa/paper/events/PlayerJoinListener.kt
@@ -1,0 +1,27 @@
+package com.github.shunsukesudo.minecraft2fa.paper.events
+
+import com.github.shunsukesudo.minecraft2fa.paper.Minecraft2FA
+import com.google.common.io.ByteStreams
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerJoinEvent
+
+class PlayerJoinListener: Listener {
+
+    @EventHandler
+    fun onPlayerJoin(event: PlayerJoinEvent) {
+        val plugin = Minecraft2FA.getInstance()
+        val player = event.player
+
+        if(!player.hasPermission("mc2fa.connect"))
+            return
+
+        val outStream = ByteStreams.newDataOutput()
+        outStream.writeUTF("AuthInformationRequest")
+        outStream.writeUTF(event.player.uniqueId.toString())
+
+        plugin.server.scheduler.runTaskLater(plugin, Runnable {
+            event.player.sendPluginMessage(plugin, "mc2fa:authentication", outStream.toByteArray())
+        }, 30)
+    }
+}

--- a/paper/src/main/java/com/github/shunsukesudo/minecraft2fa/paper/events/PluginMessagingChannelListener.kt
+++ b/paper/src/main/java/com/github/shunsukesudo/minecraft2fa/paper/events/PluginMessagingChannelListener.kt
@@ -5,6 +5,7 @@ import com.github.shunsukesudo.minecraft2fa.shared.authentication.MCUserAuthStat
 import com.google.common.io.ByteStreams
 import org.bukkit.entity.Player
 import org.bukkit.plugin.messaging.PluginMessageListener
+import java.lang.IllegalArgumentException
 import java.util.*
 
 class PluginMessagingChannelListener: PluginMessageListener {
@@ -19,13 +20,21 @@ class PluginMessagingChannelListener: PluginMessageListener {
             return
 
         val uuid = UUID.fromString(inps.readUTF())
-        val isVerified = inps.readBoolean()
+        val statusStr = inps.readUTF()
 
-        if(isVerified) {
-            MCUserAuth.setUserAuthorizationStatus(uuid, MCUserAuthStatus.AUTHORIZED)
+        val status = try {
+            MCUserAuthStatus.valueOf(statusStr)
+        } catch (e: IllegalArgumentException) {
+            MCUserAuthStatus.NOT_AUTHORIZED
         }
-        else {
-            MCUserAuth.setUserAuthorizationStatus(uuid, MCUserAuthStatus.NOT_AUTHORIZED)
+
+        when(status) {
+            MCUserAuthStatus.AUTHORIZED -> {
+                MCUserAuth.setUserAuthorizationStatus(uuid, status)
+            }
+            else -> {
+                MCUserAuth.setUserAuthorizationStatus(uuid, status)
+            }
         }
     }
 }

--- a/paper/src/main/java/com/github/shunsukesudo/minecraft2fa/paper/events/PluginMessagingChannelListener.kt
+++ b/paper/src/main/java/com/github/shunsukesudo/minecraft2fa/paper/events/PluginMessagingChannelListener.kt
@@ -1,0 +1,31 @@
+package com.github.shunsukesudo.minecraft2fa.paper.events
+
+import com.github.shunsukesudo.minecraft2fa.shared.authentication.MCUserAuth
+import com.github.shunsukesudo.minecraft2fa.shared.authentication.MCUserAuthStatus
+import com.google.common.io.ByteStreams
+import org.bukkit.entity.Player
+import org.bukkit.plugin.messaging.PluginMessageListener
+import java.util.*
+
+class PluginMessagingChannelListener: PluginMessageListener {
+    override fun onPluginMessageReceived(channel: String, player: Player, message: ByteArray) {
+        if(!channel.equals("mc2fa:authentication", ignoreCase = true))
+            return
+
+        val inps = ByteStreams.newDataInput(message)
+        val subChannel = inps.readUTF()
+
+        if(!subChannel.equals("authInformationShare", ignoreCase = true))
+            return
+
+        val uuid = UUID.fromString(inps.readUTF())
+        val isVerified = inps.readBoolean()
+
+        if(isVerified) {
+            MCUserAuth.setUserAuthorizationStatus(uuid, MCUserAuthStatus.AUTHORIZED)
+        }
+        else {
+            MCUserAuth.setUserAuthorizationStatus(uuid, MCUserAuthStatus.NOT_AUTHORIZED)
+        }
+    }
+}

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/database/SQLiteDatabase.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/database/SQLiteDatabase.kt
@@ -2,10 +2,15 @@ package com.github.shunsukesudo.minecraft2fa.shared.database
 
 import com.github.shunsukesudo.minecraft2fa.shared.configuration.DatabaseConfiguration
 import com.github.shunsukesudo.minecraft2fa.shared.configuration.PluginConfiguration
+import com.github.shunsukesudo.minecraft2fa.shared.database.auth.AuthBackupCodeTable
+import com.github.shunsukesudo.minecraft2fa.shared.database.auth.AuthInfoTable
 import com.github.shunsukesudo.minecraft2fa.shared.database.auth.Authentication
 import com.github.shunsukesudo.minecraft2fa.shared.database.integration.Integration
+import com.github.shunsukesudo.minecraft2fa.shared.database.integration.IntegrationInfoTable
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.transactions.TransactionManager
+import org.jetbrains.exposed.sql.transactions.transaction
 import java.sql.Connection
 
 internal class SQLiteDatabase(
@@ -21,6 +26,11 @@ internal class SQLiteDatabase(
 
     init {
         TransactionManager.manager.defaultIsolationLevel = Connection.TRANSACTION_SERIALIZABLE
+        transaction(database) {
+            SchemaUtils.createMissingTablesAndColumns(AuthBackupCodeTable)
+            SchemaUtils.createMissingTablesAndColumns(AuthInfoTable)
+            SchemaUtils.createMissingTablesAndColumns(IntegrationInfoTable)
+        }
     }
 
     override fun authentication(): Authentication {

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/database/auth/Authentication.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/database/auth/Authentication.kt
@@ -131,10 +131,8 @@ class Authentication(
         transaction(database) {
             bc = AuthBackupCodeTable.selectAll().where { AuthBackupCodeTable.authID eq authID }.map { it[AuthBackupCodeTable.backUpCodes] }
         }
-        if(bc.isEmpty())
-            return Collections.emptyList()
 
-        return bc
+        return if(bc.isNotEmpty()) bc else emptyList()
     }
 
     /**
@@ -154,10 +152,6 @@ class Authentication(
             }
         }
 
-        return if(authID.isEmpty()) {
-            -1
-        } else {
-            authID.first()
-        }
+        return if(authID.isNotEmpty()) authID.first() else -1
     }
 }

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/database/integration/Integration.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/database/integration/Integration.kt
@@ -189,7 +189,7 @@ class Integration(
                 it[IntegrationInfoTable.id].value
             }
         }
-        return if(playerID.first() > 0) playerID.first() else -1
+        return if(playerID.isNotEmpty()) playerID.first() else -1
     }
 
     /**
@@ -212,7 +212,7 @@ class Integration(
                 it[IntegrationInfoTable.id].value
             }
         }
-        return if(playerID.first() > 0) playerID.first() else -1
+        return if(playerID.isNotEmpty()) playerID.first() else -1
     }
 
     /**
@@ -235,7 +235,7 @@ class Integration(
                 it[IntegrationInfoTable.minecraftUUID]
             }
         }
-        return minecraftUUID.first().ifEmpty { null }
+        return if(minecraftUUID.isNotEmpty()) minecraftUUID.first().ifEmpty { null } else null
     }
 
     /**
@@ -254,6 +254,6 @@ class Integration(
                 it[IntegrationInfoTable.discordID]
             }
         }
-        return if(discordID.first() > 0) discordID.first() else -1
+        return if(discordID.isNotEmpty()) discordID.first() else -1
     }
 }

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/discord/DiscordBot.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/discord/DiscordBot.kt
@@ -3,6 +3,7 @@ package com.github.shunsukesudo.minecraft2fa.shared.discord
 import com.github.shunsukesudo.minecraft2fa.shared.configuration.DiscordBotConfiguration
 import com.github.shunsukesudo.minecraft2fa.shared.configuration.PluginConfiguration
 import com.github.shunsukesudo.minecraft2fa.shared.database.MC2FADatabase
+import com.github.shunsukesudo.minecraft2fa.shared.minecraft.SharedPlugin
 import dev.creativition.simplejdautil.SimpleJDAUtil
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.JDABuilder
@@ -46,7 +47,7 @@ class DiscordBot(
         SimpleJDAUtil.addSearchPath("com.github.shunsukesudo.minecraft2fa.shared.discord.commands.")
 
         jda = SimpleJDAUtil
-            .registerListeners(jdaBuilder, ClassLoader.getPlatformClassLoader())
+            .registerListeners(jdaBuilder, SharedPlugin.plugin.javaClass.classLoader)
             .build()
             .awaitReady()
 

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/discord/commands/AuthCommand.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/discord/commands/AuthCommand.kt
@@ -83,6 +83,11 @@ class AuthCommand: ListenerAdapter() {
 
 
     private fun registerCommandAction(event: SlashCommandInteractionEvent) {
+        if(!database.authentication().is2FAAuthenticationInformationExists(database.integration().getPlayerID(event.user.idLong))) {
+            DiscordBot.replyErrorMessage(event, "Seems you haven't integrated minecraft account with discord. Please integrate first.")
+            return
+        }
+
         if(database.authentication().is2FAAuthenticationInformationExists(database.integration().getPlayerID(event.user.idLong))) {
            event.reply("You have already registered the 2FA!").setEphemeral(true).queue()
            return
@@ -144,6 +149,11 @@ class AuthCommand: ListenerAdapter() {
 
 
     private fun unRegisterCommandAction(event: SlashCommandInteractionEvent) {
+        if(!database.authentication().is2FAAuthenticationInformationExists(database.integration().getPlayerID(event.user.idLong))) {
+            DiscordBot.replyErrorMessage(event, "Seems you haven't integrated minecraft account with discord. Please integrate first.")
+            return
+        }
+
         val secretKey = database.authentication().get2FASecretKey(database.integration().getPlayerID(event.user.idLong))
         if(secretKey == null) {
             DiscordBot.replyErrorMessage(event, "Seems you haven't registered the 2FA. Please register 2FA first.")
@@ -188,6 +198,11 @@ class AuthCommand: ListenerAdapter() {
 
 
     private fun verifyCommandAction(event: SlashCommandInteractionEvent) {
+        if(!database.authentication().is2FAAuthenticationInformationExists(database.integration().getPlayerID(event.user.idLong))) {
+            DiscordBot.replyErrorMessage(event, "Seems you haven't integrated minecraft account with discord. Please integrate first.")
+            return
+        }
+
         val secretKey = database.authentication().get2FASecretKey(database.integration().getPlayerID(event.user.idLong))
         if(secretKey == null) {
             DiscordBot.replyErrorMessage(event, "Seems you haven't registered the 2FA. Please register 2FA first.")

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/discord/commands/AuthCommand.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/discord/commands/AuthCommand.kt
@@ -6,6 +6,7 @@ import com.github.shunsukesudo.minecraft2fa.shared.authentication.User2FA
 import com.github.shunsukesudo.minecraft2fa.shared.discord.DiscordBot
 import com.github.shunsukesudo.minecraft2fa.shared.event.MC2FAEvent
 import com.github.shunsukesudo.minecraft2fa.shared.event.auth.AuthSuccessEvent
+import com.github.shunsukesudo.minecraft2fa.shared.minecraft.SharedPlugin
 import com.github.shunsukesudo.minecraft2fa.shared.util.QRCodeUtil
 import dev.creativition.simplejdautil.SimpleJDAUtil
 import dev.creativition.simplejdautil.SlashCommandBuilder
@@ -239,6 +240,9 @@ class AuthCommand: ListenerAdapter() {
         }
 
         MC2FAEvent.callEvent(AuthSuccessEvent(event.user.idLong))
+        event.reply("Your session is now verified! Your verified session will expire in ${SharedPlugin.pluginConfiguration.authConfiguration.sessionExpireTimeInSeconds} seconds.")
+            .setEphemeral(true)
+            .queue()
     }
 
 

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/discord/commands/AuthCommand.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/discord/commands/AuthCommand.kt
@@ -83,7 +83,7 @@ class AuthCommand: ListenerAdapter() {
 
 
     private fun registerCommandAction(event: SlashCommandInteractionEvent) {
-        if(!database.authentication().is2FAAuthenticationInformationExists(database.integration().getPlayerID(event.user.idLong))) {
+        if(!database.integration().isIntegrationInformationExists(event.user.idLong)) {
             DiscordBot.replyErrorMessage(event, "Seems you haven't integrated minecraft account with discord. Please integrate first.")
             return
         }
@@ -149,7 +149,7 @@ class AuthCommand: ListenerAdapter() {
 
 
     private fun unRegisterCommandAction(event: SlashCommandInteractionEvent) {
-        if(!database.authentication().is2FAAuthenticationInformationExists(database.integration().getPlayerID(event.user.idLong))) {
+        if(!database.integration().isIntegrationInformationExists(event.user.idLong)) {
             DiscordBot.replyErrorMessage(event, "Seems you haven't integrated minecraft account with discord. Please integrate first.")
             return
         }
@@ -198,7 +198,7 @@ class AuthCommand: ListenerAdapter() {
 
 
     private fun verifyCommandAction(event: SlashCommandInteractionEvent) {
-        if(!database.authentication().is2FAAuthenticationInformationExists(database.integration().getPlayerID(event.user.idLong))) {
+        if(!database.integration().isIntegrationInformationExists(event.user.idLong)) {
             DiscordBot.replyErrorMessage(event, "Seems you haven't integrated minecraft account with discord. Please integrate first.")
             return
         }

--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/event/auth/AuthSessionExpireEvent.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/event/auth/AuthSessionExpireEvent.kt
@@ -1,0 +1,13 @@
+package com.github.shunsukesudo.minecraft2fa.shared.event.auth
+
+import com.github.shunsukesudo.minecraft2fa.shared.event.GenericEvent
+import java.util.UUID
+
+class AuthSessionExpireEvent (
+    private val uuid: UUID
+): GenericEvent {
+
+    fun getUUID(): UUID {
+        return this.uuid
+    }
+}

--- a/waterfall/src/main/java/com/github/shunsukesudo/minecraft2fa/waterfall/Minecraft2FA.kt
+++ b/waterfall/src/main/java/com/github/shunsukesudo/minecraft2fa/waterfall/Minecraft2FA.kt
@@ -4,8 +4,13 @@ import com.github.shunsukesudo.minecraft2fa.shared.configuration.*
 import com.github.shunsukesudo.minecraft2fa.shared.database.DatabaseFactory
 import com.github.shunsukesudo.minecraft2fa.shared.database.MC2FADatabase
 import com.github.shunsukesudo.minecraft2fa.shared.discord.DiscordBot
+import com.github.shunsukesudo.minecraft2fa.shared.event.MC2FAEvent
 import com.github.shunsukesudo.minecraft2fa.shared.minecraft.IPlugin
 import com.github.shunsukesudo.minecraft2fa.shared.minecraft.SharedPlugin
+import com.github.shunsukesudo.minecraft2fa.waterfall.commands.MC2FACommandWaterfall
+import com.github.shunsukesudo.minecraft2fa.waterfall.events.AuthSessionExpireEventListener
+import com.github.shunsukesudo.minecraft2fa.waterfall.events.AuthSuccessEventListener
+import com.github.shunsukesudo.minecraft2fa.waterfall.events.PluginMessagingChannelListener
 import net.dv8tion.jda.api.exceptions.InvalidTokenException
 import net.md_5.bungee.api.plugin.Plugin
 import net.md_5.bungee.config.ConfigurationProvider
@@ -64,6 +69,11 @@ class Minecraft2FA: Plugin(), IPlugin {
             onDisable()
             return
         }
+
+        proxy.pluginManager.registerCommand(this, MC2FACommandWaterfall())
+
+        proxy.registerChannel("mc2fa:authentication")
+        proxy.pluginManager.registerListener(this, PluginMessagingChannelListener())
     }
 
     private fun parseConfig(): PluginConfiguration {

--- a/waterfall/src/main/java/com/github/shunsukesudo/minecraft2fa/waterfall/Minecraft2FA.kt
+++ b/waterfall/src/main/java/com/github/shunsukesudo/minecraft2fa/waterfall/Minecraft2FA.kt
@@ -18,6 +18,7 @@ class Minecraft2FA: Plugin(), IPlugin {
     companion object{
         private lateinit var pluginConfig: PluginConfiguration
         private lateinit var pluginDatabase: MC2FADatabase
+        private lateinit var pluginInstance: Plugin
 
         fun getPluginConfig(): PluginConfiguration {
             return pluginConfig
@@ -26,10 +27,15 @@ class Minecraft2FA: Plugin(), IPlugin {
         fun getDatabase(): MC2FADatabase {
             return pluginDatabase
         }
+
+        fun getInstance(): Plugin {
+            return pluginInstance
+        }
     }
 
     init {
         SharedPlugin.plugin = this
+        pluginInstance = this
     }
 
     override val pluginConfiguration: PluginConfiguration

--- a/waterfall/src/main/java/com/github/shunsukesudo/minecraft2fa/waterfall/events/PluginMessagingChannelListener.kt
+++ b/waterfall/src/main/java/com/github/shunsukesudo/minecraft2fa/waterfall/events/PluginMessagingChannelListener.kt
@@ -18,21 +18,22 @@ class PluginMessagingChannelListener: Listener {
         if (!event.tag.equals("mc2fa:authentication", ignoreCase = true))
             return
 
+        if(event.sender !is Server)
+            return
 
         val inp = ByteStreams.newDataInput(event.data)
         val subChannel = inp.readUTF()
         val userUUID = inp.readUTF()
 
-        if (subChannel.equals("authInformationShare", ignoreCase = true)){
+        if (!subChannel.equals("AuthInformationRequest", ignoreCase = true))
+            return
 
-            when(event.receiver) {
-                // message from server
-                is ProxiedPlayer -> {
-                    val receiver = event.receiver as ProxiedPlayer
-                    sendAuthData(receiver.server, UUID.fromString(userUUID))
-                }
-            }
-        }
+
+        if(event.receiver !is ProxiedPlayer)
+            return
+
+        val receiver = event.receiver as ProxiedPlayer
+        sendAuthData(receiver.server, UUID.fromString(userUUID))
     }
 
     private fun sendAuthData(server: Server, uuid: UUID){
@@ -42,7 +43,7 @@ class PluginMessagingChannelListener: Listener {
         val outStream = ByteStreams.newDataOutput()
         outStream.writeUTF("authInformationShare")
         outStream.writeUTF(uuid.toString())
-        outStream.writeBoolean(MCUserAuth.getUserAuthorizationStatus(uuid) == MCUserAuthStatus.AUTHORIZED)
+        outStream.writeUTF(MCUserAuth.getUserAuthorizationStatus(uuid).toString())
 
         server.sendData("mc2fa:authentication", outStream.toByteArray())
     }

--- a/waterfall/src/main/java/com/github/shunsukesudo/minecraft2fa/waterfall/events/PluginMessagingChannelListener.kt
+++ b/waterfall/src/main/java/com/github/shunsukesudo/minecraft2fa/waterfall/events/PluginMessagingChannelListener.kt
@@ -1,0 +1,49 @@
+package com.github.shunsukesudo.minecraft2fa.waterfall.events
+
+import com.github.shunsukesudo.minecraft2fa.shared.authentication.MCUserAuth
+import com.github.shunsukesudo.minecraft2fa.shared.authentication.MCUserAuthStatus
+import com.github.shunsukesudo.minecraft2fa.waterfall.Minecraft2FA
+import com.google.common.io.ByteStreams
+import net.md_5.bungee.api.connection.ProxiedPlayer
+import net.md_5.bungee.api.connection.Server
+import net.md_5.bungee.api.event.PluginMessageEvent
+import net.md_5.bungee.api.plugin.Listener
+import net.md_5.bungee.event.EventHandler
+import java.util.*
+
+class PluginMessagingChannelListener: Listener {
+
+    @EventHandler
+    fun onPluginMessage(event: PluginMessageEvent) {
+        if (!event.tag.equals("mc2fa:authentication", ignoreCase = true))
+            return
+
+
+        val inp = ByteStreams.newDataInput(event.data)
+        val subChannel = inp.readUTF()
+        val userUUID = inp.readUTF()
+
+        if (subChannel.equals("authInformationShare", ignoreCase = true)){
+
+            when(event.receiver) {
+                // message from server
+                is ProxiedPlayer -> {
+                    val receiver = event.receiver as ProxiedPlayer
+                    sendAuthData(receiver.server, UUID.fromString(userUUID))
+                }
+            }
+        }
+    }
+
+    private fun sendAuthData(server: Server, uuid: UUID){
+        val networkPlayers = Minecraft2FA.getInstance().proxy.players
+        if (networkPlayers.isNullOrEmpty()) return
+
+        val outStream = ByteStreams.newDataOutput()
+        outStream.writeUTF("authInformationShare")
+        outStream.writeUTF(uuid.toString())
+        outStream.writeBoolean(MCUserAuth.getUserAuthorizationStatus(uuid) == MCUserAuthStatus.AUTHORIZED)
+
+        server.sendData("mc2fa:authentication", outStream.toByteArray())
+    }
+}


### PR DESCRIPTION
## Link to ticket

* closes https://github.com/ShunsukeSudo/Minecraft2FA-Remake/issues/38

## What I did

* Implemented plugin messaging channel communication between server and proxy
* Authentication status can be shared between server and proxy with using plugin messaging channel.

## What I didn't do

* Nothing

## Operation check

~~I can't do until discord bot command fixed. see https://github.com/ShunsukeSudo/Minecraft2FA-Remake/issues/39~~

Tested with docker environment.

1. run `docker compose up -d` in docker directory.
2. Join server.
3. Check debug output (debug output has been removed on commit)