### PR TITLE
Implement database existence check and automatically create when database is SQLite

### DIFF
--- a/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/database/SQLiteDatabase.kt
+++ b/shared/src/main/java/com/github/shunsukesudo/minecraft2fa/shared/database/SQLiteDatabase.kt
@@ -2,10 +2,15 @@ package com.github.shunsukesudo.minecraft2fa.shared.database
 
 import com.github.shunsukesudo.minecraft2fa.shared.configuration.DatabaseConfiguration
 import com.github.shunsukesudo.minecraft2fa.shared.configuration.PluginConfiguration
+import com.github.shunsukesudo.minecraft2fa.shared.database.auth.AuthBackupCodeTable
+import com.github.shunsukesudo.minecraft2fa.shared.database.auth.AuthInfoTable
 import com.github.shunsukesudo.minecraft2fa.shared.database.auth.Authentication
 import com.github.shunsukesudo.minecraft2fa.shared.database.integration.Integration
+import com.github.shunsukesudo.minecraft2fa.shared.database.integration.IntegrationInfoTable
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.transactions.TransactionManager
+import org.jetbrains.exposed.sql.transactions.transaction
 import java.sql.Connection
 
 internal class SQLiteDatabase(
@@ -21,6 +26,11 @@ internal class SQLiteDatabase(
 
     init {
         TransactionManager.manager.defaultIsolationLevel = Connection.TRANSACTION_SERIALIZABLE
+        transaction(database) {
+            SchemaUtils.createMissingTablesAndColumns(AuthBackupCodeTable)
+            SchemaUtils.createMissingTablesAndColumns(AuthInfoTable)
+            SchemaUtils.createMissingTablesAndColumns(IntegrationInfoTable)
+        }
     }
 
     override fun authentication(): Authentication {


### PR DESCRIPTION

## Link to ticket

* closes https://github.com/ShunsukeSudo/Minecraft2FA-Remake/issues/42

## What I did

* Implemented database existence check and automatically create when database is SQLite

## What I didn't do

* Nothing

## Operation check

Run server with docker environment and will be printed the database transaction log.